### PR TITLE
Replace in-memory mock data with calls to server

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 import {
   DID_GET_POSTS,
   DID_GET_POST,
@@ -5,54 +7,30 @@ import {
   DID_DELETE_POST
 } from '../action_types';
 
-const mockPosts = {
-  '1': {
-    id: '1',
-    title: 'Hello, world!',
-    categories: 'misc, yay',
-    content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-  },
-  '2': {
-    id: '2',
-    title: 'Another post',
-    categories: 'stuff, woo',
-    content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-  }
-};
+const API_URL = 'http://104.236.201.225';
 
 export const getPosts = () => ({
   type: DID_GET_POSTS,
-  payload: Promise.resolve(
-    Object.keys(mockPosts).map(id => mockPosts[id])
-  )
+  payload: axios.get(`${API_URL}/posts.json`)
 });
 
 export const getPost = id => {
   return {
     type: DID_GET_POST,
-    payload: Promise.resolve(mockPosts[id])
+    payload: axios.get(`${API_URL}/posts/${id}.json`)
   };
 };
 
 export const createPost = fields => {
-  const id = Math.random().toString(36).substr(2, 8);
-
-  mockPosts[id] = {
-    ...fields,
-    id
-  };
-
   return {
     type: DID_CREATE_POST,
-    payload: Promise.resolve(mockPosts[id])
+    payload: axios.post(`${API_URL}/posts.json`)
   };
 }
 
 export const deletePost = id => {
-  delete mockPosts[id];
-
   return {
     type: DID_DELETE_POST,
-    payload: id
+    payload: axios.delete(`${API_URL}/posts/${id}.json`)
   };
 }


### PR DESCRIPTION
I built the app with mock data that the action creators "fetch" asynchronously, with the intention of replacing it with actual server data at the end.

Then when I got to the end, I hit the "No 'Access-Control-Allow-Origin'" error :D:

`master` has the working, in-memory version. This PR has the version that's connected to the server, which I assume will work once the proper header is set.

@StephenGrider 
